### PR TITLE
fix bug when the object is an array

### DIFF
--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -38,7 +38,7 @@ function emit(w, counter, circular, o, n, options) {
         var elem = n === undefined ? p + ':Array' : n;
         var child = w.startElement(elem);
         for (var idx in o) {
-            emit(child, circular, counter, o[idx], '_' + idx, options);
+            emit(child, counter, circular, o[idx], '_' + idx, options);
         }
         child.endElement(elem);
     } else {


### PR DESCRIPTION
Looks like some function parameters got swapped and emit was being called incorrectly
